### PR TITLE
fix ssl error in Python3.7

### DIFF
--- a/pages/homepage.py
+++ b/pages/homepage.py
@@ -3,7 +3,7 @@ from sites.walmart import Walmart
 from sites.bestbuy import BestBuy
 from pages.createdialog import CreateDialog
 from utils import get_profile, get_proxy, BirdLogger, return_data, write_data, open_browser
-import urllib.request,sys,platform
+import urllib.request,sys,platform,ssl
 import settings
 def no_abort(a, b, c):
     sys.__excepthook__(a, b, c)
@@ -496,6 +496,7 @@ class ImageThread(QtCore.QThread):
         QtCore.QThread.__init__(self)
 
     def run(self):
+        ssl._create_default_https_context = ssl._create_unverified_context
         data = urllib.request.urlopen(self.image_url).read()
         pixmap = QtGui.QPixmap()
         pixmap.loadFromData(data)


### PR DESCRIPTION
fix error like this:
```
File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 222, in urlopen

    return opener.open(url, data, timeout)

  File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 525, in open

    response = self._open(req, data)

  File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 543, in _open

    ‘_open’, req)

  File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 503, in _call_chain

    result = func(*args)

  File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 1360, in https_open

    context=self._context, check_hostname=self._check_hostname)

  File “/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py”, line 1319, in do_open

    raise URLError(err)

urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
```